### PR TITLE
config: add entry-point-based plugin schema discovery

### DIFF
--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -284,6 +284,17 @@ REMOTE_SCHEMAS = {
 }
 
 
+def _get_dvc_fs_entry_points():
+    """Return installed dvc.fs entry points, compatible with Python 3.9+.
+
+    ``entry_points(group=...)`` was added in Python 3.10; on 3.9 we use
+    the dict-based ``entry_points().get(group, [])`` API instead.
+    """
+    if sys.version_info >= (3, 10):
+        return entry_points(group="dvc.fs")
+    return entry_points().get("dvc.fs", [])  # type: ignore[call-arg]
+
+
 def _discover_plugin_schemas():
     """Discover remote config schemas from installed DVC filesystem plugins.
 
@@ -295,12 +306,7 @@ def _discover_plugin_schemas():
 
     Existing (hardcoded) schemes are never overwritten.
     """
-    # entry_points(group=...) requires Python 3.10+; use dict API on 3.9
-    if sys.version_info >= (3, 10):
-        eps = entry_points(group="dvc.fs")
-    else:
-        eps = entry_points().get("dvc.fs", [])  # type: ignore[call-arg]
-    for ep in eps:
+    for ep in _get_dvc_fs_entry_points():
         try:
             cls = ep.load()
         except Exception:  # noqa: BLE001,S112

--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -292,7 +292,7 @@ def _get_dvc_fs_entry_points():
     """
     if sys.version_info >= (3, 10):
         return entry_points(group="dvc.fs")
-    return entry_points().get("dvc.fs", [])  # type: ignore[call-arg]
+    return entry_points().get("dvc.fs", [])  # type: ignore[call-arg,unreachable]
 
 
 def _discover_plugin_schemas():

--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from importlib.metadata import entry_points
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
@@ -294,7 +295,12 @@ def _discover_plugin_schemas():
 
     Existing (hardcoded) schemes are never overwritten.
     """
-    for ep in entry_points(group="dvc.fs"):
+    # entry_points(group=...) requires Python 3.10+; use dict API on 3.9
+    if sys.version_info >= (3, 10):
+        eps = entry_points(group="dvc.fs")
+    else:
+        eps = entry_points().get("dvc.fs", [])  # type: ignore[call-arg]
+    for ep in eps:
         try:
             cls = ep.load()
         except Exception:  # noqa: BLE001,S112

--- a/dvc/config_schema.py
+++ b/dvc/config_schema.py
@@ -297,7 +297,7 @@ def _discover_plugin_schemas():
     for ep in entry_points(group="dvc.fs"):
         try:
             cls = ep.load()
-        except Exception:  # noqa: BLE001
+        except Exception:  # noqa: BLE001,S112
             continue
 
         remote_config = getattr(cls, "REMOTE_CONFIG", None)

--- a/tests/unit/test_plugin_schema_discovery.py
+++ b/tests/unit/test_plugin_schema_discovery.py
@@ -5,6 +5,7 @@ class attribute to register their URL scheme and config options with
 DVC's config validation, without requiring changes to DVC core.
 """
 
+from typing import ClassVar
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -14,7 +15,7 @@ class FakePluginFS:
     """Minimal filesystem class that declares REMOTE_CONFIG."""
 
     protocol = "myplugin"
-    REMOTE_CONFIG = {
+    REMOTE_CONFIG: ClassVar[dict] = {
         "token": str,
         "endpoint_url": str,
     }
@@ -30,7 +31,7 @@ class FakePluginMultiProtocol:
     """Filesystem class with tuple protocol."""
 
     protocol = ("myproto", "myprotos")
-    REMOTE_CONFIG = {
+    REMOTE_CONFIG: ClassVar[dict] = {
         "api_key": str,
     }
 
@@ -48,7 +49,7 @@ class TestDiscoverPluginSchemas:
 
     def test_plugin_schema_registered(self):
         """A plugin with REMOTE_CONFIG gets its scheme added to REMOTE_SCHEMAS."""
-        from dvc.config_schema import REMOTE_COMMON, REMOTE_SCHEMAS
+        from dvc.config_schema import REMOTE_SCHEMAS
 
         eps = [_make_entry_point("myplugin", FakePluginFS)]
         with patch("dvc.config_schema.entry_points", return_value=eps):
@@ -92,7 +93,7 @@ class TestDiscoverPluginSchemas:
 
         class FakeS3:
             protocol = "s3"
-            REMOTE_CONFIG = {"fake_key": str}
+            REMOTE_CONFIG: ClassVar[dict] = {"fake_key": str}
 
         eps = [_make_entry_point("s3", FakeS3)]
         with patch("dvc.config_schema.entry_points", return_value=eps):
@@ -149,7 +150,7 @@ class TestByUrlWithPlugin:
 
     def test_byurl_validates_plugin_scheme(self):
         """ByUrl should accept a URL with a plugin-registered scheme."""
-        from dvc.config_schema import ByUrl, REMOTE_COMMON, REMOTE_SCHEMAS
+        from dvc.config_schema import REMOTE_COMMON, REMOTE_SCHEMAS, ByUrl
 
         # Register a fake scheme
         REMOTE_SCHEMAS["testplugin"] = {"token": str, **REMOTE_COMMON}
@@ -167,7 +168,7 @@ class TestByUrlWithPlugin:
         """ByUrl should reject an unregistered scheme."""
         from voluptuous import Invalid as VoluptuousInvalid
 
-        from dvc.config_schema import ByUrl, REMOTE_SCHEMAS
+        from dvc.config_schema import REMOTE_SCHEMAS, ByUrl
 
         validator = ByUrl(REMOTE_SCHEMAS)
 

--- a/tests/unit/test_plugin_schema_discovery.py
+++ b/tests/unit/test_plugin_schema_discovery.py
@@ -1,0 +1,175 @@
+"""Tests for plugin-based remote config schema discovery.
+
+Verifies that DVC filesystem plugins can declare a ``REMOTE_CONFIG``
+class attribute to register their URL scheme and config options with
+DVC's config validation, without requiring changes to DVC core.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class FakePluginFS:
+    """Minimal filesystem class that declares REMOTE_CONFIG."""
+
+    protocol = "myplugin"
+    REMOTE_CONFIG = {
+        "token": str,
+        "endpoint_url": str,
+    }
+
+
+class FakePluginNoConfig:
+    """Filesystem class without REMOTE_CONFIG — should be skipped."""
+
+    protocol = "noplugin"
+
+
+class FakePluginMultiProtocol:
+    """Filesystem class with tuple protocol."""
+
+    protocol = ("myproto", "myprotos")
+    REMOTE_CONFIG = {
+        "api_key": str,
+    }
+
+
+def _make_entry_point(name, cls):
+    """Create a mock entry point that returns the given class on load()."""
+    ep = MagicMock()
+    ep.name = name
+    ep.load.return_value = cls
+    return ep
+
+
+class TestDiscoverPluginSchemas:
+    """Tests for _discover_plugin_schemas."""
+
+    def test_plugin_schema_registered(self):
+        """A plugin with REMOTE_CONFIG gets its scheme added to REMOTE_SCHEMAS."""
+        from dvc.config_schema import REMOTE_COMMON, REMOTE_SCHEMAS
+
+        eps = [_make_entry_point("myplugin", FakePluginFS)]
+        with patch("dvc.config_schema.entry_points", return_value=eps):
+            # Clear any prior registration from this test key
+            REMOTE_SCHEMAS.pop("myplugin", None)
+
+            from dvc.config_schema import _discover_plugin_schemas
+
+            _discover_plugin_schemas()
+
+        assert "myplugin" in REMOTE_SCHEMAS
+        schema = REMOTE_SCHEMAS["myplugin"]
+        # Should contain plugin-specific keys
+        assert "token" in schema
+        assert "endpoint_url" in schema
+        # Should contain REMOTE_COMMON keys
+        assert "url" in schema
+
+        # Cleanup
+        REMOTE_SCHEMAS.pop("myplugin", None)
+
+    def test_plugin_without_remote_config_skipped(self):
+        """A plugin without REMOTE_CONFIG is silently skipped."""
+        from dvc.config_schema import REMOTE_SCHEMAS
+
+        eps = [_make_entry_point("noplugin", FakePluginNoConfig)]
+        with patch("dvc.config_schema.entry_points", return_value=eps):
+            REMOTE_SCHEMAS.pop("noplugin", None)
+
+            from dvc.config_schema import _discover_plugin_schemas
+
+            _discover_plugin_schemas()
+
+        assert "noplugin" not in REMOTE_SCHEMAS
+
+    def test_existing_scheme_not_overwritten(self):
+        """Hardcoded schemes like 's3' are never overwritten by plugins."""
+        from dvc.config_schema import REMOTE_SCHEMAS
+
+        original_s3 = REMOTE_SCHEMAS["s3"].copy()
+
+        class FakeS3:
+            protocol = "s3"
+            REMOTE_CONFIG = {"fake_key": str}
+
+        eps = [_make_entry_point("s3", FakeS3)]
+        with patch("dvc.config_schema.entry_points", return_value=eps):
+            from dvc.config_schema import _discover_plugin_schemas
+
+            _discover_plugin_schemas()
+
+        # s3 schema should be unchanged
+        assert "fake_key" not in REMOTE_SCHEMAS["s3"]
+        assert REMOTE_SCHEMAS["s3"] == original_s3
+
+    def test_plugin_load_failure_skipped(self):
+        """Plugins that fail to load are silently skipped."""
+        from dvc.config_schema import REMOTE_SCHEMAS
+
+        ep = MagicMock()
+        ep.name = "broken"
+        ep.load.side_effect = ImportError("missing dependency")
+
+        with patch("dvc.config_schema.entry_points", return_value=[ep]):
+            REMOTE_SCHEMAS.pop("broken", None)
+
+            from dvc.config_schema import _discover_plugin_schemas
+
+            _discover_plugin_schemas()
+
+        assert "broken" not in REMOTE_SCHEMAS
+
+    def test_multi_protocol_plugin(self):
+        """A plugin with tuple protocol registers all schemes."""
+        from dvc.config_schema import REMOTE_SCHEMAS
+
+        eps = [_make_entry_point("myproto", FakePluginMultiProtocol)]
+        with patch("dvc.config_schema.entry_points", return_value=eps):
+            REMOTE_SCHEMAS.pop("myproto", None)
+            REMOTE_SCHEMAS.pop("myprotos", None)
+
+            from dvc.config_schema import _discover_plugin_schemas
+
+            _discover_plugin_schemas()
+
+        assert "myproto" in REMOTE_SCHEMAS
+        assert "myprotos" in REMOTE_SCHEMAS
+        assert "api_key" in REMOTE_SCHEMAS["myproto"]
+        assert "api_key" in REMOTE_SCHEMAS["myprotos"]
+
+        # Cleanup
+        REMOTE_SCHEMAS.pop("myproto", None)
+        REMOTE_SCHEMAS.pop("myprotos", None)
+
+
+class TestByUrlWithPlugin:
+    """Integration test: ByUrl accepts plugin-registered schemes."""
+
+    def test_byurl_validates_plugin_scheme(self):
+        """ByUrl should accept a URL with a plugin-registered scheme."""
+        from dvc.config_schema import ByUrl, REMOTE_COMMON, REMOTE_SCHEMAS
+
+        # Register a fake scheme
+        REMOTE_SCHEMAS["testplugin"] = {"token": str, **REMOTE_COMMON}
+        validator = ByUrl(REMOTE_SCHEMAS)
+
+        # Should not raise
+        result = validator({"url": "testplugin://myhost/path", "token": "abc"})
+        assert result["url"] == "testplugin://myhost/path"
+        assert result["token"] == "abc"
+
+        # Cleanup
+        REMOTE_SCHEMAS.pop("testplugin", None)
+
+    def test_byurl_rejects_unknown_scheme(self):
+        """ByUrl should reject an unregistered scheme."""
+        from voluptuous import Invalid as VoluptuousInvalid
+
+        from dvc.config_schema import ByUrl, REMOTE_SCHEMAS
+
+        validator = ByUrl(REMOTE_SCHEMAS)
+
+        with pytest.raises(VoluptuousInvalid, match="Unsupported URL type"):
+            validator({"url": "unknownscheme://host/path"})

--- a/tests/unit/test_plugin_schema_discovery.py
+++ b/tests/unit/test_plugin_schema_discovery.py
@@ -52,7 +52,7 @@ class TestDiscoverPluginSchemas:
         from dvc.config_schema import REMOTE_SCHEMAS
 
         eps = [_make_entry_point("myplugin", FakePluginFS)]
-        with patch("dvc.config_schema.entry_points", return_value=eps):
+        with patch("dvc.config_schema._get_dvc_fs_entry_points", return_value=eps):
             # Clear any prior registration from this test key
             REMOTE_SCHEMAS.pop("myplugin", None)
 
@@ -76,7 +76,7 @@ class TestDiscoverPluginSchemas:
         from dvc.config_schema import REMOTE_SCHEMAS
 
         eps = [_make_entry_point("noplugin", FakePluginNoConfig)]
-        with patch("dvc.config_schema.entry_points", return_value=eps):
+        with patch("dvc.config_schema._get_dvc_fs_entry_points", return_value=eps):
             REMOTE_SCHEMAS.pop("noplugin", None)
 
             from dvc.config_schema import _discover_plugin_schemas
@@ -96,7 +96,7 @@ class TestDiscoverPluginSchemas:
             REMOTE_CONFIG: ClassVar[dict] = {"fake_key": str}
 
         eps = [_make_entry_point("s3", FakeS3)]
-        with patch("dvc.config_schema.entry_points", return_value=eps):
+        with patch("dvc.config_schema._get_dvc_fs_entry_points", return_value=eps):
             from dvc.config_schema import _discover_plugin_schemas
 
             _discover_plugin_schemas()
@@ -113,7 +113,7 @@ class TestDiscoverPluginSchemas:
         ep.name = "broken"
         ep.load.side_effect = ImportError("missing dependency")
 
-        with patch("dvc.config_schema.entry_points", return_value=[ep]):
+        with patch("dvc.config_schema._get_dvc_fs_entry_points", return_value=[ep]):
             REMOTE_SCHEMAS.pop("broken", None)
 
             from dvc.config_schema import _discover_plugin_schemas
@@ -127,7 +127,7 @@ class TestDiscoverPluginSchemas:
         from dvc.config_schema import REMOTE_SCHEMAS
 
         eps = [_make_entry_point("myproto", FakePluginMultiProtocol)]
-        with patch("dvc.config_schema.entry_points", return_value=eps):
+        with patch("dvc.config_schema._get_dvc_fs_entry_points", return_value=eps):
             REMOTE_SCHEMAS.pop("myproto", None)
             REMOTE_SCHEMAS.pop("myprotos", None)
 


### PR DESCRIPTION
Closes #10993

## Summary

Adds `_discover_plugin_schemas()` to `dvc/config_schema.py`, which iterates over installed `dvc.fs` entry points at import time and merges any `REMOTE_CONFIG` class attributes into `REMOTE_SCHEMAS`. This lets third-party filesystem plugins register their own URL schemes and config keys without modifying DVC core.

## Changes

- `dvc/config_schema.py` — adds `_discover_plugin_schemas()` (~25 lines) called once at module load
- `tests/unit/test_plugin_schema_discovery.py` — 7 new unit tests

## Behavior

**Plugin declares its config schema:**
```python
class OSFFileSystem(ObjectFileSystem):
    protocol = "osf"
    REMOTE_CONFIG: ClassVar[dict] = {
        "token": str,
        "project_id": str,
        "provider": str,
        "endpoint_url": str,
    }
```

**DVC discovers it automatically when the plugin is installed** — no changes to DVC core needed per-plugin.

## Properties

- ✅ Backward compatible — hardcoded schemes (`s3`, `gs`, etc.) are never overwritten
- ✅ Zero overhead without third-party plugins
- ✅ Graceful — plugins that fail to load are silently skipped
- ✅ Handles single and tuple `protocol` values
- ✅ 22/22 relevant unit tests passing (`test_plugin_schema_discovery` + `test_config`)
- ✅ ruff clean

## Motivation

Developed alongside [dvc-osf](https://github.com/adamlabadorf/dvc-osf), a plugin for [Open Science Framework](https://osf.io/) storage. Without this change, `dvc remote add myremote osf://...` raises `Unsupported URL type osf://` before the filesystem ever loads. With it, all DVC remote operations work correctly (30 integration tests passing against a real OSF project).