### PR TITLE
test: add regression test for --pull path nesting bug (#11005)

### DIFF
--- a/tests/func/test_import.py
+++ b/tests/func/test_import.py
@@ -765,3 +765,40 @@ def test_import_no_hash(
     assert {
         call.args[1] for call in index_info_spy.call_args_list
     } == expected_info_calls
+
+
+def test_import_no_download_exp_run_pull_no_nesting(tmp_dir, dvc, scm, erepo_dir):
+    with erepo_dir.chdir():
+        erepo_dir.dvc_gen(
+            {"data": {"MNIST": {"raw": {"t10k-images": "dummy content"}}}},
+            commit="add data",
+        )
+
+    tmp_dir.gen({"dvc.yaml": ""})
+
+    dvc.imp(
+        url=os.fspath(erepo_dir),
+        path="data/",
+        out="remote_data",
+        no_download=True,
+    )
+
+    scm.add(["remote_data.dvc", "dvc.yaml", ".gitignore"])
+    scm.commit("Initial import with --no-download")
+
+    dvc.experiments.run(pull=True)
+
+    assert (tmp_dir / "remote_data" / "MNIST").exists()
+    assert not (tmp_dir / "remote_data" / "data").exists()
+
+    original_dvc_content = (tmp_dir / "remote_data.dvc").read_text()
+
+    remove(tmp_dir / "remote_data")
+
+    dvc.experiments.run(pull=True)
+
+    assert (tmp_dir / "remote_data" / "MNIST").exists()
+    assert not (tmp_dir / "remote_data" / "data").exists()
+
+    new_dvc_content = (tmp_dir / "remote_data.dvc").read_text()
+    assert original_dvc_content == new_dvc_content


### PR DESCRIPTION
**What changed and why?**

This PR adds a failing regression test to `tests/func/test_import.py` to capture a path-resolution bug reported in **Issue #11005.**

Currently, running `dvc exp run --pull` on a repository where data was imported using `dvc import --no-download` behaves correctly the first time. However, if the local target directory is deleted, a subsequent `--pull` command improperly nests the source directory inside the target (creating `target/source/...` instead of `target/...`). This changes the directory structure and MD5 hash, breaking reproducibility.

**How it was implemented:**

I added a test using `pytest` and DVC's `erepo_dir` fixture that programmatically reproduces the exact workflow:

1. Initializes a repo and runs `dvc import --no-download`.
2. Runs `dvc exp run --pull`.
3. Deletes the target directory.
4. Runs `dvc exp run --pull` again.
5. Asserts that the improperly nested `data/` directory does not exist.

Note: I am submitting this failing test first to provide a reproducible baseline while I continue investigating the ImportStage path mapping logic for a full fix.

References #11005

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/treeverse/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
