### PR TITLE
tests: add subdir dvcignore test

### DIFF
--- a/dvc/dependency/base.py
+++ b/dvc/dependency/base.py
@@ -1,6 +1,10 @@
+from typing import Optional
+
 from dvc.exceptions import DvcException
 from dvc.fs import download as fs_download
+from dvc.ignore import DvcIgnoreFilter
 from dvc.output import Output
+from dvc_objects.fs.scheme import Schemes
 
 
 class DependencyDoesNotExistError(DvcException):
@@ -26,6 +30,26 @@ class Dependency(Output):
     DoesNotExistError: type[DvcException] = DependencyDoesNotExistError
     IsNotFileOrDirError: type[DvcException] = DependencyIsNotFileOrDirError
     IsStageFileError: type[DvcException] = DependencyIsStageFileError
+
+    @property
+    def dvcignore(self) -> Optional[DvcIgnoreFilter]:
+        """
+        For dependencies we override the dvcignore to be part of
+        SCM root as well. Outputs cannot be saved outside the DVC repo.
+        However, you can have dependency for subdir DVC repos.
+
+        Returns:
+            Optional[DvcIgnoreFilter]: DVC repo root or SCM root dvcignore.
+        """
+        if self.fs.protocol != Schemes.LOCAL:
+            return None
+
+        assert self.repo
+        if self.fs.isin_or_eq(self.fs_path, self.repo.root_dir):
+            return self.repo.dvcignore
+        if self.fs.isin_or_eq(self.fs_path, self.repo.scm.root_dir):
+            return self.repo.scm_dvcignore
+        return None
 
     def workspace_status(self) -> dict[str, str]:
         if self.fs.version_aware:

--- a/dvc/dependency/base.py
+++ b/dvc/dependency/base.py
@@ -1,10 +1,6 @@
-from typing import Optional
-
 from dvc.exceptions import DvcException
 from dvc.fs import download as fs_download
-from dvc.ignore import DvcIgnoreFilter
 from dvc.output import Output
-from dvc_objects.fs.scheme import Schemes
 
 
 class DependencyDoesNotExistError(DvcException):
@@ -30,26 +26,6 @@ class Dependency(Output):
     DoesNotExistError: type[DvcException] = DependencyDoesNotExistError
     IsNotFileOrDirError: type[DvcException] = DependencyIsNotFileOrDirError
     IsStageFileError: type[DvcException] = DependencyIsStageFileError
-
-    @property
-    def dvcignore(self) -> Optional[DvcIgnoreFilter]:
-        """
-        For dependencies we override the dvcignore to be part of
-        SCM root as well. Outputs cannot be saved outside the DVC repo.
-        However, you can have dependency for subdir DVC repos.
-
-        Returns:
-            Optional[DvcIgnoreFilter]: DVC repo root or SCM root dvcignore.
-        """
-        if self.fs.protocol != Schemes.LOCAL:
-            return None
-
-        assert self.repo
-        if self.fs.isin_or_eq(self.fs_path, self.repo.root_dir):
-            return self.repo.dvcignore
-        if self.fs.isin_or_eq(self.fs_path, self.repo.scm.root_dir):
-            return self.repo.scm_dvcignore
-        return None
 
     def workspace_status(self) -> dict[str, str]:
         if self.fs.version_aware:

--- a/dvc/output.py
+++ b/dvc/output.py
@@ -34,9 +34,11 @@ from dvc_data.hashfile.meta import Meta
 from dvc_data.hashfile.transfer import transfer as otransfer
 from dvc_data.hashfile.tree import Tree, du
 from dvc_objects.errors import ObjectFormatError
+from dvc_objects.fs.local import LocalFileSystem
+from dvc_objects.fs.scheme import Schemes
 
 from .annotations import ANNOTATION_FIELDS, ANNOTATION_SCHEMA, Annotation
-from .fs import LocalFileSystem, RemoteMissingDepsError, Schemes, get_cloud_fs
+from .fs import RemoteMissingDepsError, get_cloud_fs
 from .fs.callbacks import DEFAULT_CALLBACK, Callback, TqdmCallback
 from .utils import relpath
 from .utils.fs import path_isin
@@ -351,7 +353,7 @@ class Output:
         self.fs = fs_cls(**fs_config)
 
         if (
-            self.fs.protocol == "local"
+            self.fs.protocol == Schemes.LOCAL
             and stage
             and isinstance(stage.repo.fs, LocalFileSystem)
             and path_isin(path, stage.repo.root_dir)
@@ -363,7 +365,7 @@ class Output:
 
         if (
             self.repo
-            and self.fs.protocol == "local"
+            and self.fs.protocol == Schemes.LOCAL
             and not self.fs.isabs(self.def_path)
         ):
             self.fs = self.repo.fs
@@ -461,7 +463,7 @@ class Output:
         return f"{type(self).__name__}: {self.def_path!r}"
 
     def __str__(self):
-        if self.fs.protocol != "local":
+        if self.fs.protocol != Schemes.LOCAL:
             return self.def_path
 
         if (
@@ -643,7 +645,7 @@ class Output:
 
     @property
     def dvcignore(self) -> Optional["DvcIgnoreFilter"]:
-        if self.fs.protocol == "local":
+        if self.fs.protocol == Schemes.LOCAL:
             assert self.repo
             return self.repo.dvcignore
         return None
@@ -891,7 +893,7 @@ class Output:
         return ret
 
     def verify_metric(self):
-        if self.fs.protocol != "local":
+        if self.fs.protocol != Schemes.LOCAL:
             raise DvcException(f"verify metric is not supported for {self.protocol}")
         if not self.metric:
             return
@@ -1003,7 +1005,7 @@ class Output:
         else:
             logger.warning("%r missing", self.fspath)
 
-        if self.protocol == "local" and self.use_scm_ignore:
+        if self.protocol == Schemes.LOCAL and self.use_scm_ignore:
             assert self.repo
             self.repo.scm_context.ignore_remove(self.fspath)
 

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -330,13 +330,14 @@ class Repo:
 
     @cached_property
     def dvcignore(self) -> DvcIgnoreFilter:
-        return DvcIgnoreFilter(self.fs, self.root_dir)
+        from dvc.scm import NoSCM
 
-    @cached_property
-    def scm_dvcignore(self) -> DvcIgnoreFilter:
-        if self.root_dir == self.scm.root_dir:
-            return self.dvcignore
-        return DvcIgnoreFilter(self.fs, self.scm.root_dir)
+        if isinstance(self.scm, NoSCM):
+            root_dir = self.root_dir
+        else:
+            root_dir = self.scm.root_dir
+
+        return DvcIgnoreFilter(self.fs, root_dir)
 
     def get_rev(self):
         from dvc.fs import GitFileSystem, LocalFileSystem

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -330,14 +330,13 @@ class Repo:
 
     @cached_property
     def dvcignore(self) -> DvcIgnoreFilter:
-        from dvc.scm import NoSCM
+        return DvcIgnoreFilter(self.fs, self.root_dir)
 
-        if isinstance(self.scm, NoSCM):
-            root_dir = self.root_dir
-        else:
-            root_dir = self.scm.root_dir
-
-        return DvcIgnoreFilter(self.fs, root_dir)
+    @cached_property
+    def scm_dvcignore(self) -> DvcIgnoreFilter:
+        if self.root_dir == self.scm.root_dir:
+            return self.dvcignore
+        return DvcIgnoreFilter(self.fs, self.scm.root_dir)
 
     def get_rev(self):
         from dvc.fs import GitFileSystem, LocalFileSystem

--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -332,6 +332,12 @@ class Repo:
     def dvcignore(self) -> DvcIgnoreFilter:
         return DvcIgnoreFilter(self.fs, self.root_dir)
 
+    @cached_property
+    def scm_dvcignore(self) -> DvcIgnoreFilter:
+        if self.root_dir == self.scm.root_dir:
+            return self.dvcignore
+        return DvcIgnoreFilter(self.fs, self.scm.root_dir)
+
     def get_rev(self):
         from dvc.fs import GitFileSystem, LocalFileSystem
 

--- a/tests/func/test_ignore.py
+++ b/tests/func/test_ignore.py
@@ -7,7 +7,7 @@ import pytest
 from dvc.ignore import DvcIgnore, DvcIgnorePatterns
 from dvc.output import OutputIsIgnoredError
 from dvc.pathspec_math import PatternInfo, merge_patterns
-from dvc.repo import Repo
+from dvc.repo import Repo, lock_repo
 from dvc.testing.tmp_dir import TmpDir
 from dvc_data.hashfile.build import IgnoreInCollectedDirError
 from dvc_data.hashfile.utils import get_mtime_and_size
@@ -225,6 +225,38 @@ def test_ignore_external(tmp_dir, scm, dvc, tmp_path_factory):
     }
     assert dvc.dvcignore.is_ignored_dir(os.fspath(ext_dir / "tmp")) is False
     assert dvc.dvcignore.is_ignored_file(os.fspath(ext_dir / "y.backup")) is False
+
+
+def test_subdir_repo_uses_scm_root_dvcignore_for_external_dependency(tmp_dir, scm):
+    tmp_dir.gen(
+        {
+            ".dvcignore": "*.pyc\n",
+            "main_lib": {"foo.py": "VALUE = 1\n"},
+            "sudirs_monorepo": {"proj1": {}},
+        }
+    )
+
+    subrepo_dir = tmp_dir / "sudirs_monorepo" / "proj1"
+    with subrepo_dir.chdir():
+        repo = Repo.init(subdir=True)
+        stage = repo.stage.create(
+            name="check-main-lib",
+            cmd="echo check",
+            deps=[os.path.join("..", "..", "main_lib")],
+            outs=[],
+        )
+        stage.save(run_cache=False)
+
+        pycache_dir = tmp_dir / "main_lib" / "__pycache__"
+        pycache_dir.mkdir()
+        (pycache_dir / "foo.pyc").write_bytes(b"ignored bytecode")
+
+        with lock_repo(repo):
+            assert not stage.changed_deps()
+
+        (tmp_dir / "main_lib" / "new.txt").write_text("not ignored")
+        with lock_repo(repo):
+            assert stage.changed_deps()
 
 
 def test_ignore_resurface_subrepo(tmp_dir, scm, dvc):


### PR DESCRIPTION
* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/treeverse/dvc.org) and linked it here.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏

This fixes Issue #11044 

Now, having `.dvcignore` in the root of the SCM dir will be respected on the dependency files. This fix is especially useful for monorepos.
