### PR TITLE
api: resolve get_url path relative to repo root

### DIFF
--- a/dvc/repo/__init__.py
+++ b/dvc/repo/__init__.py
@@ -388,8 +388,12 @@ class Repo:
         workspace: str = "repo",
     ) -> tuple["DataIndex", "DataIndexEntry"]:
         if self.subrepos:
-            fs_path = self.dvcfs.from_os_path(path)
             fs = self.dvcfs.fs
+            fs_path = self.dvcfs.from_os_path(path)
+            # `path` is relative to the repo root, so anchor it there instead of
+            # letting it resolve against the current working directory (#11029).
+            if not fs_path.startswith(fs.root_marker):
+                fs_path = fs.join(fs.root_marker, fs_path)
             key = fs._get_key_from_relative(fs_path)
             subrepo, _, key = fs._get_subrepo_info(key)
             index = subrepo.index.data[workspace]

--- a/tests/func/api/test_data.py
+++ b/tests/func/api/test_data.py
@@ -32,6 +32,18 @@ def test_get_url_requires_dvc(tmp_dir, scm):
         api.get_url("foo", repo=f"file://{tmp_dir.as_posix()}")
 
 
+def test_get_url_from_subdir(tmp_dir, dvc, local_remote):
+    # `path` is documented as relative to the repo root, so the result must not
+    # depend on the current working directory (see #11029).
+    tmp_dir.dvc_gen("foo", "foo")
+    subdir = tmp_dir / "subdir"
+    subdir.mkdir()
+
+    expected = api.get_url("foo", repo=os.fspath(tmp_dir))
+    with subdir.chdir():
+        assert api.get_url("foo", repo=os.fspath(tmp_dir)) == expected
+
+
 def test_get_url_from_remote(tmp_dir, erepo_dir, cloud, local_cloud):
     erepo_dir.add_remote(config=cloud.config, name="other")
     erepo_dir.add_remote(config=local_cloud.config, default=True)


### PR DESCRIPTION
Closes #11029

### Bug

`dvc.api.get_url()` documents its `path` argument as *relative to the root of
`repo`*, but it raised `OutputNotFoundError` whenever it was called from a
subdirectory of the repo:

```python
os.chdir(repo_root / "subdir")
api.get_url("foo", repo=repo_root)   # OutputNotFoundError: Unable to find DVC file with output 'foo'
```

### Cause

`Repo.get_data_index_entry()` (the only caller of `get_url`'s lookup) builds
the data-index key via `_DVCFileSystem._get_key_from_relative()`, which resolves
a *relative* path against the filesystem's current working directory. From
`subdir/`, `"foo"` became the key `("subdir", "foo")` instead of `("foo",)`, so
the entry was not found. From the repo root (or outside the repo) the cwd
happened to map to the root marker, which is why the bug only showed up in a
subdirectory.

### Fix

Anchor the (root-relative) path at the dvcfs root marker before computing the
key, so the lookup no longer depends on the current working directory. This
matches the documented contract of `path`.

### Tests

- `tests/func/api/test_data.py::test_get_url_from_subdir` — `get_url` returns
  the same URL from the repo root and from a subdirectory. Fails before the fix
  (`OutputNotFoundError`), passes after.

All `tests/func/api/test_data.py` (35) and `tests/unit/fs/test_dvc.py` (40)
pass locally; `ruff check` / `ruff format --check` are clean.
