### PR TITLE
docs: fix parameter name mismatches in docstrings

### DIFF
--- a/dvc/repo/experiments/queue/base.py
+++ b/dvc/repo/experiments/queue/base.py
@@ -90,7 +90,7 @@ class BaseStashQueue(ABC):
         """Construct a queue.
 
         Arguments:
-            scm: Git SCM instance for this queue.
+            repo: DVC repo instance for this queue.
             ref: Git stash ref for this queue.
             failed_ref: Failed run Git stash ref for this queue.
         """

--- a/dvc/repo/experiments/queue/tasks.py
+++ b/dvc/repo/experiments/queue/tasks.py
@@ -84,8 +84,8 @@ def cleanup_exp(executor: TempDirExecutor, infofile: str) -> None:
     """Cleanup after an experiment.
 
     Arguments:
-        tmp_dir: Temp directory to be removed.
-        entry_dict: Serialized QueueEntry for this experiment.
+        executor: Executor to clean up.
+        infofile: Path to the executor info file.
     """
     executor.cleanup(infofile)
 


### PR DESCRIPTION
Fixes two docstrings where the documented parameter names don't match the actual function signatures:

| File | Function | Docstring said | Signature has |
|------|----------|---------------|---------------|
| `dvc/repo/experiments/queue/base.py` | `BaseStashQueue.__init__` | `scm` | `repo` |
| `dvc/repo/experiments/queue/tasks.py` | `cleanup_exp` | `tmp_dir`, `entry_dict` (stale) | `executor`, `infofile` |

Doc-only change; no behavior modified.