### PR TITLE
fix(repro): record dependency hashes before running the stage command (#11058)

### DIFF
--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -638,7 +638,9 @@ class Stage(params.StageParams):
     def _run_stage(self, dry, force, **kwargs) -> None:
         if not dry:
             self._frozen_deps = None
-            old_hashes = {dep: (dep.hash_info, getattr(dep, "meta", None)) for dep in self.deps}
+            old_hashes = {
+                dep: (dep.hash_info, getattr(dep, "meta", None)) for dep in self.deps
+            }
             # Freeze dependency hashes *before* the command runs, so dvc.lock
             # records the inputs actually used to produce the outputs.
             # Recomputing them after the run (in save()) would capture any
@@ -646,7 +648,8 @@ class Stage(params.StageParams):
             # code<->output linkage. See issue #11058.
             self.save_deps(allow_missing=True)
             self._frozen_deps = {
-                id(dep): (dep.hash_info, getattr(dep, "meta", None)) for dep in self.deps
+                id(dep): (dep.hash_info, getattr(dep, "meta", None))
+                for dep in self.deps
             }
             for dep, (old_hash, old_meta) in old_hashes.items():
                 dep.hash_info = old_hash

--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -163,6 +163,7 @@ class Stage(params.StageParams):
         self.desc: Optional[str] = desc
         self.meta = meta
         self.raw_data = RawData()
+        self._frozen_deps: Optional[dict] = None
 
     @property
     def path(self) -> str:
@@ -491,23 +492,35 @@ class Stage(params.StageParams):
 
     def save(self, allow_missing: bool = False, run_cache: bool = True):
         self.save_deps(allow_missing=allow_missing)
-
         self.save_outs(allow_missing=allow_missing)
-
         self.md5 = self.compute_md5()
-
         if run_cache:
             self.repo.stage_cache.save(self)
 
     def save_deps(self, allow_missing=False):
         from dvc.dependency.base import DependencyDoesNotExistError
 
+        frozen = self._frozen_deps
         for dep in self.deps:
             try:
                 dep.save()
             except DependencyDoesNotExistError:
                 if not allow_missing:
                     raise
+                continue
+            pre = frozen.get(id(dep)) if frozen else None
+            if pre is not None and dep.hash_info != pre[0]:
+                logger.warning(
+                    "Dependency '%s' of %s was modified while the stage "
+                    "command was running. Recording its pre-run hash so the "
+                    "outputs stay linked to the inputs that produced them; "
+                    "the stage will be reported as changed on the next run.",
+                    dep,
+                    self,
+                )
+                dep.hash_info = pre[0]
+                if hasattr(dep, "meta"):
+                    dep.meta = pre[1]
 
     def save_outs(self, allow_missing: bool = False):
         from dvc.output import OutputDoesNotExistError
@@ -607,7 +620,6 @@ class Stage(params.StageParams):
         if not dry:
             if no_download:
                 allow_missing = True
-
             no_cache_outs = any(
                 not out.use_cache
                 for out in self.outs
@@ -617,7 +629,6 @@ class Stage(params.StageParams):
                 allow_missing=allow_missing,
                 run_cache=not no_commit and not no_cache_outs,
             )
-
             if no_download:
                 self.ignore_outs()
             if not no_commit:
@@ -625,6 +636,22 @@ class Stage(params.StageParams):
 
     @rwlocked(read=["deps"], write=["outs"])
     def _run_stage(self, dry, force, **kwargs) -> None:
+        if not dry:
+            self._frozen_deps = None
+            old_hashes = {dep: (dep.hash_info, getattr(dep, "meta", None)) for dep in self.deps}
+            # Freeze dependency hashes *before* the command runs, so dvc.lock
+            # records the inputs actually used to produce the outputs.
+            # Recomputing them after the run (in save()) would capture any
+            # change made to a dependency during execution and falsify the
+            # code<->output linkage. See issue #11058.
+            self.save_deps(allow_missing=True)
+            self._frozen_deps = {
+                id(dep): (dep.hash_info, getattr(dep, "meta", None)) for dep in self.deps
+            }
+            for dep, (old_hash, old_meta) in old_hashes.items():
+                dep.hash_info = old_hash
+                if hasattr(dep, "meta"):
+                    dep.meta = old_meta
         return run_stage(self, dry, force, **kwargs)
 
     @rwlocked(read=["deps"], write=["outs"])

--- a/tests/func/repro/test_repro.py
+++ b/tests/func/repro/test_repro.py
@@ -1296,3 +1296,37 @@ def test_repro_external_outputs(tmp_dir, dvc, local_workspace, persist):
     assert (local_workspace / "foo").read_text() == "foo"
     assert (local_workspace / "bar").read_text() == "foo"
     assert not (local_workspace / "cache").exists()
+
+
+def test_repro_records_pre_run_dep_hash(tmp_dir, dvc, caplog):
+    # code.py is its own dependency; running it mutates code.py,
+    # simulating a dependency being edited while the stage runs.
+    code = (
+        "from pathlib import Path\n"
+        "Path('out.txt').write_text('produced')\n"
+        "Path('code.py').write_text(Path('code.py').read_text() + '\\n# mutated\\n')\n"
+    )
+    tmp_dir.gen("code.py", code)
+    (tmp_dir / "dvc.yaml").dump(
+        {
+            "stages": {
+                "build": {
+                    "cmd": "python code.py",
+                    "deps": ["code.py"],
+                    "outs": ["out.txt"],
+                }
+            }
+        }
+    )
+
+    reproduced = dvc.reproduce("build")
+    assert reproduced  # it ran the first time
+
+    # The dep hash in the lock must correspond to the ORIGINAL code.py,
+    # so it must NOT match the now-mutated workspace file -> stage is "changed".
+    # (Under the bug, status is empty / up-to-date here.)
+    assert dvc.status(["build"]) != {}
+
+    # A second reproduce must actually re-run, not skip.
+    # (Under the bug, this returns [] because the lock matches the mutated file.)
+    assert dvc.reproduce("build")


### PR DESCRIPTION
Fixes #11058.

## Problem
`dvc repro` computes dependency hashes *after* the stage command finishes.
If a dependency is modified while the command is running, `dvc.lock` records
the post-run hash, so the outputs get linked to the wrong version of the
inputs and the stage is incorrectly reported as unchanged (and skipped) on
the next run.

## Fix
Snapshot dependency hashes *before* the command runs (in `_run_stage`) and
use them when writing `dvc.lock`. If a dependency changed during execution,
the pre-run hash is kept and a warning is logged; because the recorded hash
then differs from the mutated workspace file, the stage is correctly reported
as changed on the next run and re-executed.

`run()` and `save()` are unchanged — the logic lives in `_run_stage` and
`save_deps`, keyed by `id(dep)` so it is robust across regular deps and params.

Note: dependencies are hashed twice per run (once for the snapshot, once in
the post-run `save`). This is negligible for typical code/config deps and was
kept for a small, obviously-correct diff. Happy to reuse the snapshot in the
post-run save instead if preferred.

## Test
Added `test_repro_records_pre_run_dep_hash` in `tests/func/repro/test_repro.py`,
which uses a self-mutating command to deterministically simulate a mid-run
dependency change and asserts the stage is reported as changed and re-runs.

- [x] I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.
- [ ] This PR does not require documentation updates.