### PR TITLE
fix: close ODB index after remote operations

### DIFF
--- a/dvc/data_cloud.py
+++ b/dvc/data_cloud.py
@@ -1,6 +1,7 @@
 """Manages dvc remotes that user can use with push/pull/status commands."""
 
 from collections.abc import Iterable
+from contextlib import closing
 from typing import TYPE_CHECKING, Optional
 
 from dvc.config import NoRemoteError, RemoteConfigError
@@ -210,16 +211,19 @@ class DataCloud:
             cache = self.repo.cache.legacy
         else:
             cache = self.repo.cache.local
-        with TqdmCallback(
-            desc=f"Pushing to {odb.fs.unstrip_protocol(odb.path)}",
-            unit="file",
-        ) as cb:
+        with (
+            closing(get_index(odb)) as index,
+            TqdmCallback(
+                desc=f"Pushing to {odb.fs.unstrip_protocol(odb.path)}",
+                unit="file",
+            ) as cb,
+        ):
             return self.transfer(
                 cache,
                 odb,
                 objs,
                 jobs=jobs,
-                dest_index=get_index(odb),
+                dest_index=index,
                 cache_odb=cache,
                 validate_status=self._log_missing,
                 callback=cb,
@@ -271,16 +275,19 @@ class DataCloud:
             cache = self.repo.cache.legacy
         else:
             cache = self.repo.cache.local
-        with TqdmCallback(
-            desc=f"Fetching from {odb.fs.unstrip_protocol(odb.path)}",
-            unit="file",
-        ) as cb:
+        with (
+            closing(get_index(odb)) as index,
+            TqdmCallback(
+                desc=f"Fetching from {odb.fs.unstrip_protocol(odb.path)}",
+                unit="file",
+            ) as cb,
+        ):
             return self.transfer(
                 odb,
                 cache,
                 objs,
                 jobs=jobs,
-                src_index=get_index(odb),
+                src_index=index,
                 cache_odb=cache,
                 verify=odb.verify,
                 validate_status=self._log_missing,
@@ -340,14 +347,15 @@ class DataCloud:
             cache = self.repo.cache.legacy
         else:
             cache = self.repo.cache.local
-        return compare_status(
-            cache,
-            odb,
-            objs,
-            jobs=jobs,
-            dest_index=get_index(odb),
-            cache_odb=cache,
-        )
+        with closing(get_index(odb)) as index:
+            return compare_status(
+                cache,
+                odb,
+                objs,
+                jobs=jobs,
+                dest_index=index,
+                cache_odb=cache,
+            )
 
     def get_url_for(self, remote, checksum):
         odb = self.get_remote_odb(remote)

--- a/dvc/repo/gc.py
+++ b/dvc/repo/gc.py
@@ -88,7 +88,7 @@ def gc(  # noqa: C901, PLR0912, PLR0913
         not_in_remote=not_in_remote,
     )
 
-    from contextlib import ExitStack
+    from contextlib import ExitStack, closing
 
     from dvc.repo import Repo
     from dvc_data.hashfile.db import get_index
@@ -148,7 +148,8 @@ def gc(  # noqa: C901, PLR0912, PLR0913
         assert remote_odb is not None
         num_removed = ogc(remote_odb, obj_ids, jobs=jobs, dry=dry)
         if num_removed:
-            get_index(remote_odb).clear()
+            with closing(get_index(remote_odb)) as index:
+                index.clear()
             logger.info("Removed %d objects from remote.", num_removed)
         else:
             logger.info("No unused cache to remove from remote.")


### PR DESCRIPTION
### Close ODB remote index after use

`DataCloud._push` / `_pull` / `_status` and the cloud branch of `repo.gc` each build a remote index via `get_index(odb)` and never close it. That index (`ObjectDBIndex`) wraps a `diskcache.Cache`, which holds an open SQLite connection — so every push/pull/status/gc leaks one connection until it's garbage-collected. It shows up as a flood of

```
ResourceWarning: unclosed database in <sqlite3.Connection object at 0x...>
```

which is easy to miss normally (ResourceWarning is off by default) but is very visible under `pytest --cov`, where coverage keeps objects alive and shifts GC into the warning-capture window.

`ObjectDBIndex.close()` already exists in `dvc_data` — it just wasn't being called. The index is only used within the single `transfer()` / `compare_status()` / `clear()` call and only on the calling thread (the `jobs` parallelism lives in `odb.oids_exist(...)` / `dest.add(...)`, which don't touch the index), so wrapping each site with `contextlib.closing` closes the connection deterministically.

#### Changes
- `dvc/data_cloud.py`: `closing(get_index(odb))` in `_push`, `_pull`, `_status`
- `dvc/repo/gc.py`: same for the cloud gc path
- `tests/unit/test_data_cloud.py`: assert the index is closed for push/pull/status

No user-facing or API change; the index is purely a local cache. No docs update needed.

---

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.
* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/treeverse/dvc.org) and linked it here. — N/A, no docs impact