### PR TITLE
fix: compare the whole value in env2bool

### DIFF
--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -237,14 +237,19 @@ def as_posix(path: str) -> str:
     return path.replace(ntpath.sep, posixpath.sep)
 
 
+TRUTHY_VALUES = frozenset({"1", "y", "yes", "true"})
+
+
 def env2bool(var, undefined=False):
     """
     undefined: return value if env var is unset
     """
-    var = os.getenv(var, None)
-    if var is None:
+    value = os.getenv(var, None)
+    if value is None:
         return undefined
-    return bool(re.search("1|y|yes|true", var, flags=re.IGNORECASE))
+    # Compare the whole value: a substring search treats any value that merely
+    # contains "1" or "y" (e.g. "deny", "only", "10") as true.
+    return value.strip().lower() in TRUTHY_VALUES
 
 
 def resolve_output(inp: str, out: Optional[str], force=False) -> str:

--- a/tests/unit/utils/test_env2bool.py
+++ b/tests/unit/utils/test_env2bool.py
@@ -1,0 +1,31 @@
+import pytest
+
+from dvc.utils import env2bool
+
+VAR = "DVC_TEST_ENV2BOOL"
+
+
+def test_unset_returns_undefined(monkeypatch):
+    monkeypatch.delenv(VAR, raising=False)
+    assert env2bool(VAR) is False
+    assert env2bool(VAR, undefined=True) is True
+
+
+@pytest.mark.parametrize("value", ["1", "y", "yes", "true", "TRUE", "Yes", " true "])
+def test_truthy_values(monkeypatch, value):
+    monkeypatch.setenv(VAR, value)
+    assert env2bool(VAR) is True
+
+
+@pytest.mark.parametrize("value", ["0", "n", "no", "false", "off", ""])
+def test_falsy_values(monkeypatch, value):
+    monkeypatch.setenv(VAR, value)
+    assert env2bool(VAR) is False
+
+
+@pytest.mark.parametrize("value", ["deny", "only", "anything", "my-value", "10", "1a"])
+def test_values_merely_containing_a_truthy_token_are_false(monkeypatch, value):
+    # The value is compared as a whole: a substring search would treat anything
+    # containing "1" or "y" as true, so "deny" and "10" would enable a flag.
+    monkeypatch.setenv(VAR, value)
+    assert env2bool(VAR) is False


### PR DESCRIPTION
## Problem

`env2bool` uses `re.search`, which matches a truthy token **anywhere inside** the value rather than comparing the value as a whole:

```python
return bool(re.search("1|y|yes|true", var, flags=re.IGNORECASE))
```

So any value that merely contains a `1` or a `y` turns the flag on:

```
deny      -> True     # the user is clearly saying "no"
only      -> True
anything  -> True
my-value  -> True
10        -> True
1a        -> True
```

`env2bool` gates real switches - `DVC_EXP_AUTO_PUSH`, `DVC_SQLALCHEMY_ECHO`, `DVC_IGNORE_ISATTY`, `DVC_TEST` - so e.g. `DVC_EXP_AUTO_PUSH=deny` silently **enables** auto-push, which is the opposite of what was asked for.

## Change

Compare the stripped, lowercased value against the set of truthy tokens:

```python
TRUTHY_VALUES = frozenset({"1", "y", "yes", "true"})
...
return value.strip().lower() in TRUTHY_VALUES
```

The accepted values are unchanged - `1`, `y`, `yes`, `true`, still case-insensitive, and surrounding whitespace is still tolerated (`" true "` stays true, as it was under the old substring search). The only behaviour that changes is that values which merely *contain* one of those tokens are now correctly false.

## Tests

Added `tests/unit/utils/test_env2bool.py`: unset/`undefined`, the truthy set (incl. `TRUE`, `Yes`, `" true "`), the falsy set (`0`, `n`, `no`, `false`, `off`, `""`), and the regression cases above.

The six regression cases (`deny`, `only`, `anything`, `my-value`, `10`, `1a`) fail on `main` and pass with this change; all 20 pass with it. `ruff check` and `ruff format` clean.

Note: `tests/unit/test_progress.py::test_default` and the `dvc_http` collection errors already fail on a clean `main` in my environment and are unrelated to this change.

An AI assistant helped spot and implement this fix; I reviewed the change and ran the tests and linter locally.
