### PR TITLE
tests: cover ensure_list and nested_contains

### DIFF
--- a/tests/unit/utils/test_collections.py
+++ b/tests/unit/utils/test_collections.py
@@ -4,7 +4,9 @@ import pytest
 
 from dvc.utils.collections import (
     apply_diff,
+    ensure_list,
     merge_dicts,
+    nested_contains,
     remove_missing_keys,
     to_omegaconf,
 )
@@ -139,3 +141,31 @@ def test_remove_missing_keys(changes, expected):
     assert removed == expected == params
     assert params is removed  # references should be preserved
     assert is_serializable(params)
+
+
+@pytest.mark.parametrize(
+    "item, expected",
+    [
+        (None, []),
+        ("foo", ["foo"]),
+        (["foo", "bar"], ["foo", "bar"]),
+        (("foo", "bar"), ["foo", "bar"]),
+        ([], []),
+    ],
+)
+def test_ensure_list(item, expected):
+    assert ensure_list(item) == expected
+
+
+@pytest.mark.parametrize(
+    "dictionary, phrase, expected",
+    [
+        ({"foo": 1, "bar": 2}, "foo", True),
+        ({"foo": 0}, "foo", False),  # falsy value does not count
+        ({"foo": {"bar": {"baz": 1}}}, "baz", True),  # nested match
+        ({"foo": 1}, "bar", False),  # missing key
+        ({}, "foo", False),
+    ],
+)
+def test_nested_contains(dictionary, phrase, expected):
+    assert nested_contains(dictionary, phrase) is expected


### PR DESCRIPTION
## Description

`ensure_list` and `nested_contains` in `dvc/utils/collections.py` were untested. This extends `tests/unit/utils/test_collections.py` with:

- `ensure_list` for `None`, a bare string, a list, a tuple, and an empty list
- `nested_contains` for a flat match, a falsy value (not a match), a nested match, a missing key, and an empty dict

No source changes.

## Verification

`pytest tests/unit/utils/test_collections.py` - the two new parametrized tests pass (10 cases). `ruff check` / `ruff format --check` clean.
