### PR TITLE
tests: add unit tests for dict_filter

### DIFF
--- a/tests/unit/utils/test_dict_filter.py
+++ b/tests/unit/utils/test_dict_filter.py
@@ -1,0 +1,30 @@
+from dvc.utils import dict_filter
+
+
+def test_flat_exclusion():
+    assert dict_filter({"a": 1, "b": 2}, exclude=["b"]) == {"a": 1}
+
+
+def test_multiple_excludes():
+    assert dict_filter({"a": 1, "b": 2, "c": 3}, exclude=["a", "c"]) == {"b": 2}
+
+
+def test_nested_key_removed_recursively():
+    assert dict_filter({"a": {"b": 2, "c": 3}}, exclude=["b"]) == {"a": {"c": 3}}
+
+
+def test_excluded_key_removes_its_subtree():
+    assert dict_filter({"a": 1, "b": {"x": 1}}, exclude=["b"]) == {"a": 1}
+
+
+def test_list_of_dicts_is_filtered_elementwise():
+    result = dict_filter([{"b": 1, "a": 2}, {"a": 3}], exclude=["b"])
+    assert result == [{"a": 2}, {"a": 3}]
+
+
+def test_no_exclude_returns_input_unchanged():
+    assert dict_filter({"a": 1}) == {"a": 1}
+
+
+def test_scalar_is_passed_through():
+    assert dict_filter(5, exclude=["b"]) == 5


### PR DESCRIPTION
## Description

`dvc.utils.dict_filter` recursively drops a set of keys from a nested
dict/list structure (it backs `dict_hash`), but had no direct test coverage.

This adds `tests/unit/utils/test_dict_filter.py` covering:

- flat exclusion and multiple excluded keys
- nested keys being removed recursively
- an excluded key removing its whole subtree
- a list of dicts being filtered element-wise
- an empty `exclude` returning the input unchanged
- a scalar being passed through untouched

No source changes.

## Verification

`pytest tests/unit/utils/test_dict_filter.py` - 7 passed. `ruff check` /
`ruff format --check` clean.
