### PR TITLE
fix: fall back to full index when pull/checkout targets mix .dvc files and paths

### DIFF
--- a/dvc/repo/index.py
+++ b/dvc/repo/index.py
@@ -972,7 +972,13 @@ def index_from_targets(
                     index = Index(repo, stages=list(stages))
                 indexes.append(index)
         except (StageFileDoesNotExistError, StageNotFound):
-            pass
+            # A target that is not a stage/.dvc file (e.g. a granular path inside a
+            # tracked directory) aborts the per-target merge partway through. Reset
+            # to fall back to the full repo index with the original targets, rather
+            # than keeping the partial index built only from the targets parsed
+            # before the failure — using that partial index with the full targets
+            # list silently drops the unparsed targets and can crash checkout (#11075).
+            index = None
         else:
             index = Index.from_indexes(repo, indexes)
             targets = None

--- a/dvc/repo/index.py
+++ b/dvc/repo/index.py
@@ -966,19 +966,18 @@ def index_from_targets(
                     continue
                 file, name = parse_target(target)
                 if file and not name:
-                    index = Index.from_file(repo, file)
+                    idx = Index.from_file(repo, file)
                 else:
                     stages = repo.stage.collect(target)
-                    index = Index(repo, stages=list(stages))
-                indexes.append(index)
+                    idx = Index(repo, stages=list(stages))
+                indexes.append(idx)
         except (StageFileDoesNotExistError, StageNotFound):
-            # A target that is not a stage/.dvc file (e.g. a granular path inside a
-            # tracked directory) aborts the per-target merge partway through. Reset
-            # to fall back to the full repo index with the original targets, rather
-            # than keeping the partial index built only from the targets parsed
-            # before the failure — using that partial index with the full targets
-            # list silently drops the unparsed targets and can crash checkout (#11075).
-            index = None
+            # A target that is not a stage/.dvc file, such as a granular path
+            # inside a tracked directory, aborts the per-target merge partway
+            # through. Fall back to the full repo index with the original
+            # targets: a partial index built only from the targets parsed
+            # before the failure silently drops the rest (#11075).
+            pass
         else:
             index = Index.from_indexes(repo, indexes)
             targets = None

--- a/tests/func/test_data_cloud.py
+++ b/tests/func/test_data_cloud.py
@@ -222,6 +222,44 @@ def test_verify_hashes(tmp_dir, scm, dvc, mocker, tmp_path_factory, local_remote
     assert hash_spy.call_count == 10
 
 
+def test_pull_mixed_dvcfile_and_granular_targets(tmp_dir, scm, dvc, local_remote):
+    """Regression test for #11075.
+
+    A ``pull`` target list that mixes a ``.dvc``-file target with a granular path
+    inside a tracked directory used to build a partial index from only the
+    ``.dvc`` target while still filtering against the full target list, so the
+    granular target was silently skipped (or, when the directory had drifted,
+    ``checkout`` crashed with an uncaught ``KeyError``).
+    """
+    tmp_dir.dvc_gen(
+        {"datadir": {"f1.txt": "one", "f2.txt": "two", "f3.txt": "three"}},
+        commit="add dir",
+    )
+    tmp_dir.dvc_gen("single.csv", "single", commit="add single")
+    dvc.push()
+
+    mixed_targets = ["single.csv.dvc", join("datadir", "f1.txt")]
+
+    # Fresh-clone state: the granular target must be checked out, not skipped.
+    remove("datadir")
+    remove("single.csv")
+    dvc.cache.local.clear()
+
+    dvc.pull(mixed_targets)
+
+    assert (tmp_dir / "datadir" / "f1.txt").read_text() == "one"
+    assert (tmp_dir / "single.csv").read_text() == "single"
+
+    # A drifted (untracked) file inside the tracked directory must not turn the
+    # mixed-target pull into an uncaught KeyError during checkout.
+    dvc.pull()
+    (tmp_dir / "datadir" / "extra-drift.txt").write_text("extra")
+
+    dvc.pull(mixed_targets)  # must not raise
+
+    assert (tmp_dir / "datadir" / "f1.txt").read_text() == "one"
+
+
 # @pytest.mark.flaky(reruns=3)
 @pytest.mark.parametrize("erepo_type", ["git_dir", "erepo_dir"])
 def test_pull_git_imports(request, tmp_dir, dvc, scm, erepo_type):


### PR DESCRIPTION
Fixes #11075.

## Problem

`dvc pull` (and `dvc checkout`) with a target list that mixes a **`.dvc`-file target** with a **granular path inside a tracked directory** misbehaves two ways, both reported in #11075:

- **Fresh-clone state:** the granular target is silently skipped — pull exits 0 but never checks it out.
- **Drifted directory** (any untracked file inside the tracked dir): checkout dies with an uncaught `KeyError` / `StorageKeyError`:
  ```
  ERROR: unexpected error - ('datadir', 'f1.txt')
  ```

Each target form works on its own, and an all-data-path target list works too (that's the documented workaround).

## Root cause

`index_from_targets` (`dvc/repo/index.py`) builds a merged per-target index when **all** targets are stages/`.dvc` files, and otherwise falls back to the full repo index. The fallback is gated on `index is None` — but `index` is also the loop variable holding each per-target index:

```python
index: Optional[Index] = None
if targets and all(targets) and not with_deps and not recursive:
    indexes = []
    try:
        for target in targets:
            ...
            if file and not name:
                index = Index.from_file(repo, file)   # .dvc target: succeeds
            else:
                index = Index(repo, stages=list(repo.stage.collect(target)))
            indexes.append(index)
    except (StageFileDoesNotExistError, StageNotFound):
        pass                                          # <-- leaves partial `index`
    else:
        index = Index.from_indexes(repo, indexes)
        targets = None

if index is None:                                     # <-- skipped: index is partial
    index = repo.index
return index.targets_view(targets, ...)
```

With a mixed list like `["single.csv.dvc", "datadir/f1.txt"]`, the `.dvc` target sets `index`, then the granular path raises. The `except` does `pass`, leaving the **partial** single-target index in place, so the `index is None` fallback is skipped and that partial index — which knows nothing about the directory — is used with the **full** target list. The directory target is dropped (silent skip), and when the dir has drifted, `checkout._check_can_delete` looks up a key that isn't in the partial index's `storage_map` and raises.

All-data-path lists already work only because their first target fails immediately, so `index` stays `None` and the fallback fires.

## Fix

Reset `index = None` in the `except`, so a partial parse falls back to the full repo index with the original targets — the same working path that all-data-path target lists already take. One line.

## Test

Added `test_pull_mixed_dvcfile_and_granular_targets` (`tests/func/test_data_cloud.py`) covering both the silent-skip and the drift-crash cases with a `local_remote`. It fails on `main` (skip + `KeyError`) and passes with the fix. Verified `tests/func/test_checkout.py` (48), `tests/func/test_repo_index.py` (19), and `tests/unit/repo/` (109) still pass; `ruff check`/`format` clean.