### PR TITLE
fix: keep params named size or nfiles in the stage hash

### DIFF
--- a/dvc/stage/cache.py
+++ b/dvc/stage/cache.py
@@ -8,7 +8,7 @@ from dvc import fs
 from dvc.config import RemoteConfigError
 from dvc.exceptions import CollectCacheError, DvcException
 from dvc.log import logger
-from dvc.utils import dict_sha256, relpath
+from dvc.utils import dict_filter, dict_sha256, relpath
 
 if TYPE_CHECKING:
     from dvc_objects.db import ObjectDB
@@ -28,9 +28,23 @@ class RunCacheNotSupported(DvcException):
 def _get_cache_hash(cache, key=False):
     from dvc_data.hashfile.meta import Meta
 
+    from .params import StageParams
+
     if key:
         cache["outs"] = [out["path"] for out in cache.get("outs", [])]
-    return dict_sha256(cache, exclude=[Meta.PARAM_SIZE, Meta.PARAM_NFILES])
+
+    # size and nfiles are file metadata rather than part of the stage
+    # definition, so they do not belong in the hash. They only ever appear
+    # under deps and outs: excluding them from the whole lockfile would also
+    # drop a parameter named size or nfiles, hiding changes to it from the
+    # run-cache.
+    meta_only = (StageParams.PARAM_DEPS, StageParams.PARAM_OUTS)
+    exclude = [Meta.PARAM_SIZE, Meta.PARAM_NFILES]
+    filtered = {
+        name: dict_filter(value, exclude) if name in meta_only else value
+        for name, value in cache.items()
+    }
+    return dict_sha256(filtered)
 
 
 def _can_hash(stage):

--- a/tests/unit/stage/test_cache.py
+++ b/tests/unit/stage/test_cache.py
@@ -203,3 +203,34 @@ def test_unhashable(tmp_dir, dvc, mocker, kwargs):
     with pytest.raises(RunCacheNotFoundError):
         cache.restore(stage)
     get_stage_hash.assert_not_called()
+
+
+def _lockfile(size):
+    return {
+        "cmd": "python script.py",
+        "deps": [{"path": "script.py", "hash": "md5", "md5": "abc", "size": 10}],
+        "params": {"params.yaml": {"size": size, "nfiles": 2}},
+        "outs": [{"path": "out", "hash": "md5", "md5": "def", "size": 3}],
+    }
+
+
+def test_cache_hash_tracks_params_named_like_meta():
+    """A param named size or nfiles must still affect the stage hash.
+
+    The meta exclusion used to apply to the whole lockfile, so a param with
+    one of those names was dropped before hashing and changes to it could not
+    invalidate the run-cache.
+    """
+    from dvc.stage.cache import _get_cache_hash
+
+    assert _get_cache_hash(_lockfile(30)) != _get_cache_hash(_lockfile(40))
+
+
+def test_cache_hash_still_excludes_deps_and_outs_meta():
+    from dvc.stage.cache import _get_cache_hash
+
+    grown = _lockfile(30)
+    grown["deps"][0]["size"] = 4096
+    grown["outs"][0]["size"] = 8192
+
+    assert _get_cache_hash(_lockfile(30)) == _get_cache_hash(grown)


### PR DESCRIPTION
Fixes #10296.

## Problem

A parameter named `size` or `nfiles` is invisible to the run-cache, so changing it does not
re-run the stage and the outputs from the previous run are checked out instead. Reproduced
on current `main`:

```console
$ cat params.yaml
size: 30
count: 30

$ dvc stage add -n gen -p size,count -d gen.py -o out.txt "python gen.py"
$ dvc repro
$ cat out.txt
size=30 count=30

# changing an ordinary param re-runs the stage
$ sed -i '' 's/count: 30/count: 40/' params.yaml && dvc repro
Running stage 'gen': ...

# changing 'size' does not
$ sed -i '' 's/size: 30/size: 40/' params.yaml && dvc repro
Stage 'gen' is cached - skipping run, checking out outputs

$ cat out.txt
size=30 count=40     # stale: the new value never took effect
```

The failure is silent, which is what makes it nasty — the stage reports as cached and the
outputs look valid.

## Cause

`_get_cache_hash()` excludes `size` and `nfiles` because they are file metadata rather than
part of the stage definition, but it passes the exclusion to `dict_sha256()` for the whole
lockfile, and `dict_filter()` is recursive:

```python
return dict_sha256(cache, exclude=[Meta.PARAM_SIZE, Meta.PARAM_NFILES])
```

The lockfile has four top-level sections — `cmd`, `deps`, `params`, `outs` — and metadata
only ever appears under `deps` and `outs`. `params` holds arbitrary user keys, so a
parameter literally named `size` or `nfiles` was stripped along with the metadata and never
reached the hash.

This matches @skshetry's reading on the issue: *"We are recursively excluding `nfiles` and
`size` before hashing for stage cache, which is incorrect. Most likely, we'll be able to
remove `size` and `nfiles` only from outputs that are not parameter dependencies."*

## Fix

Apply the exclusion to the `deps` and `outs` sections only.

**Existing run-cache entries stay valid.** For a stage without a parameter of either name,
the filtered dictionary is identical to what the old code produced, so the hash is
unchanged. Only stages that were mis-hashed get a new hash, which is the point.

Verified directly:

| case | result |
|---|---|
| ordinary stage, old hash vs new hash | identical → run-cache preserved |
| `size: 30` vs `size: 40`, old code | identical → the bug |
| `size: 30` vs `size: 40`, new code | different → fixed |
| `size` under `deps`/`outs` changed | identical → metadata still excluded |

And end to end, on the reproduction above: `size` changes now re-run the stage and
`out.txt` tracks the parameter, while an unchanged pipeline still reports
`Data and pipelines are up to date.`

## Tests

Two unit tests in `tests/unit/stage/test_cache.py`:

- `test_cache_hash_tracks_params_named_like_meta` — the regression. Fails on `main`
  (the two hashes are equal), passes here.
- `test_cache_hash_still_excludes_deps_and_outs_meta` — guards the behavior that must not
  change; passes both before and after.

```
pytest tests/unit/stage/                                                # 84 passed
pytest tests/func/test_run_cache.py tests/func/test_stage.py \
       tests/func/params/ tests/func/repro/                             # 150 passed
```

`tests/unit/stage/` also reports two failures in my environment
(`test_fill_from_lock_use_appropriate_checksum`, `test_dump_nondefault_hash`), both
`ImportError: s3 is supported, but requires 'dvc-s3' to be installed`. They are unrelated:
the failing test ids are identical with and without this change.

`ruff check`, `ruff format --check` and `mypy dvc/stage/cache.py` are clean.

## Note on scope

@TimCosemans reported the same symptom on the issue for parameters named `time_dummies` and
`method`. Those names are not excluded anywhere in the hashing path, so I believe that is a
different problem and have deliberately left it alone rather than widen this change; happy
to look at it separately if it is still reproducible.
