### PR TITLE
fix: env2bool matches truthy values exactly

### DIFF
--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -244,7 +244,7 @@ def env2bool(var, undefined=False):
     var = os.getenv(var, None)
     if var is None:
         return undefined
-    return bool(re.search("1|y|yes|true", var, flags=re.IGNORECASE))
+    return var.lower() in {"1", "y", "yes", "true"}
 
 
 def resolve_output(inp: str, out: Optional[str], force=False) -> str:

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -3,7 +3,48 @@ import re
 
 import pytest
 
-from dvc.utils import dict_sha256, fix_env, parse_target, relpath, resolve_output
+from dvc.utils import (
+    dict_sha256,
+    env2bool,
+    fix_env,
+    parse_target,
+    relpath,
+    resolve_output,
+)
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("1", True),
+        ("y", True),
+        ("yes", True),
+        ("true", True),
+        ("TRUE", True),
+        ("Yes", True),
+        ("0", False),
+        ("no", False),
+        ("false", False),
+        ("off", False),
+        ("", False),
+        # only the exact truthy values count, not values containing them
+        ("my_path", False),
+        ("anything", False),
+        ("only", False),
+        ("v1.0", False),
+        ("yep", False),
+        ("yesplease", False),
+    ],
+)
+def test_env2bool(monkeypatch, value, expected):
+    monkeypatch.setenv("DVC_TEST_ENV2BOOL", value)
+    assert env2bool("DVC_TEST_ENV2BOOL") is expected
+
+
+def test_env2bool_undefined(monkeypatch):
+    monkeypatch.delenv("DVC_TEST_ENV2BOOL", raising=False)
+    assert env2bool("DVC_TEST_ENV2BOOL") is False
+    assert env2bool("DVC_TEST_ENV2BOOL", True) is True
 
 
 @pytest.mark.skipif(os.name == "nt", reason="pyenv-win is not supported")


### PR DESCRIPTION
Fixes #11080.

## What

`dvc.utils.env2bool` decided truthiness with an unanchored `re.search("1|y|yes|true", ...)`, so any env value that merely *contained* `1`, `y`, `yes` or `true` was treated as true — e.g. `my_path`, `anything`, `only`, `v1.0`, `yep`.

## Why

`env2bool` is used for `DVC_EXP_AUTO_PUSH`, `DVC_IGNORE_ISATTY`, `DVC_SQLALCHEMY_ECHO` and `DVC_TEST`, so unrelated values silently flip behavior on. The truthy values were always intended to be exactly `1` / `y` / `yes` / `true`.

## How

Match the exact truthy values (case-insensitively) instead of a substring search:

```python
return var.lower() in {"1", "y", "yes", "true"}
```

## Tests

Parametrized regression test covering the intended truthy/falsy values plus the false positives above; all fail on `main`, pass with the fix. `tests/unit/utils` and the env2bool-adjacent suites (`test_progress`, `test_analytics`, `test_updater`) pass; ruff check + format clean.
