### PR TITLE
Match the whole value in env2bool

### DIFF
--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -244,7 +244,10 @@ def env2bool(var, undefined=False):
     var = os.getenv(var, None)
     if var is None:
         return undefined
-    return bool(re.search("1|y|yes|true", var, flags=re.IGNORECASE))
+    # Match the whole value rather than a substring: re.search made any value
+    # containing "1", "y", "yes" or "true" truthy, so a path, branch name or
+    # version string read as enabled.
+    return var.strip().lower() in ("1", "y", "yes", "true")
 
 
 def resolve_output(inp: str, out: Optional[str], force=False) -> str:

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -3,7 +3,14 @@ import re
 
 import pytest
 
-from dvc.utils import dict_sha256, fix_env, parse_target, relpath, resolve_output
+from dvc.utils import (
+    dict_sha256,
+    env2bool,
+    fix_env,
+    parse_target,
+    relpath,
+    resolve_output,
+)
 
 
 @pytest.mark.skipif(os.name == "nt", reason="pyenv-win is not supported")
@@ -148,3 +155,36 @@ def test_hint_on_lockfile():
 )
 def test_dict_sha256(d, sha):
     assert dict_sha256(d) == sha
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("1", True),
+        ("y", True),
+        ("yes", True),
+        ("true", True),
+        ("TRUE", True),
+        (" 1 ", True),
+        ("0", False),
+        ("n", False),
+        ("no", False),
+        ("false", False),
+        ("off", False),
+        # values that merely contain a truthy token must not read as true
+        ("my_path", False),
+        ("anything", False),
+        ("only", False),
+        ("v1.0", False),
+        ("nay", False),
+    ],
+)
+def test_env2bool(monkeypatch, value, expected):
+    monkeypatch.setenv("DVC_TEST_ENV2BOOL", value)
+    assert env2bool("DVC_TEST_ENV2BOOL") is expected
+
+
+def test_env2bool_undefined(monkeypatch):
+    monkeypatch.delenv("DVC_TEST_ENV2BOOL", raising=False)
+    assert env2bool("DVC_TEST_ENV2BOOL") is False
+    assert env2bool("DVC_TEST_ENV2BOOL", undefined=True) is True


### PR DESCRIPTION
Fixes #11080

`env2bool` decided truthiness with an unanchored `re.search`, so any value that merely *contained* `1`, `y`, `yes` or `true` was treated as true:

```python
DVC_EXP_AUTO_PUSH=my_path   -> True    # contains "y"
DVC_EXP_AUTO_PUSH=anything  -> True    # contains "y"
DVC_EXP_AUTO_PUSH=v1.0      -> True    # contains "1"
DVC_EXP_AUTO_PUSH=nay       -> True    # contains "y"
```

It was also asymmetric in a way that's hard to reason about: `no` is correctly false, but `nay` is true.

This matters because these are user-facing environment variables where the input is arbitrary text — `DVC_EXP_AUTO_PUSH`, `DVC_SQLALCHEMY_ECHO`, `DVC_IGNORE_ISATTY`, `DVC_TEST`. The likely way to hit it is a value meant to be negative that happens to contain a matching letter, or a non-boolean value put in one of these by mistake, which silently switches the feature on instead of being ignored.

### Change

Compare the whole value, after `strip()` and `lower()`, against the set of accepted affirmatives.

Every value that was intentionally supported still works (`1`, `y`, `yes`, `true`, and case/whitespace variants); only substring matches stop being truthy. The `undefined=` behaviour for an unset variable is unchanged.

Note this is technically a behaviour change for anyone currently relying on a loose value being truthy — but since that path is indistinguishable from "user set something that isn't a boolean", tightening it seems clearly right. Happy to add a warning on unrecognised values instead if you'd prefer a softer landing.

### Tests

`test_env2bool` is parametrised over the accepted affirmatives, the common negatives, and the five substring cases above; `test_env2bool_undefined` pins the unset behaviour.

```
$ pytest tests/unit/utils/test_utils.py -k env2bool
17 passed
```

Five of them fail on `main`.
