### PR TITLE
Don't reproduce frozen stages with --force

### DIFF
--- a/dvc/stage/__init__.py
+++ b/dvc/stage/__init__.py
@@ -422,6 +422,13 @@ class Stage(params.StageParams):
         allow_missing = kwargs.get("allow_missing", False)
         pull = kwargs.get("pull", False)
         upstream = kwargs.pop("upstream", None)
+        if self.frozen and not self.is_import:
+            # `dvc freeze` documents a frozen stage as always treated as
+            # unchanged, so `--force` must not reproduce it. The command is
+            # skipped in `run()` either way, but reproducing re-saves the stage
+            # and rewrites its dependency hashes in dvc.lock. Falling through to
+            # the checks below still lets it restore missing outputs.
+            force = False
         if force:
             pass
         # Skip stages with missing data if otherwise unchanged

--- a/tests/func/repro/test_repro.py
+++ b/tests/func/repro/test_repro.py
@@ -17,7 +17,7 @@ from dvc.stage.cache import RunCacheNotSupported
 from dvc.stage.exceptions import StageFileDoesNotExistError, StageNotFound
 from dvc.testing import matchers as M
 from dvc.utils.fs import remove
-from dvc.utils.serialize import modify_yaml
+from dvc.utils.serialize import load_yaml, modify_yaml
 from dvc_data.hashfile.hash import file_md5
 
 
@@ -54,6 +54,21 @@ def test_repro_frozen(tmp_dir, dvc, run_copy):
     tmp_dir.gen("data", "bar")
     stages = dvc.reproduce()
     assert stages == [data_stage, stage0]
+
+
+def test_repro_frozen_force(tmp_dir, dvc, run_copy):
+    """Check that `--force` doesn't rewrite a frozen stage's dependency hashes"""
+    tmp_dir.dvc_gen("data", "foo")
+    run_copy("data", "stage0", name="copy-data-stage0")
+    run_copy("stage0", "stage1", name="copy-data-stage1")
+
+    dvc.freeze("copy-data-stage1")
+    frozen_before = load_yaml("dvc.lock")["stages"]["copy-data-stage1"]
+
+    tmp_dir.gen("stage0", "bar")
+
+    assert dvc.reproduce("copy-data-stage1", force=True) == []
+    assert load_yaml("dvc.lock")["stages"]["copy-data-stage1"] == frozen_before
 
 
 def test_downstream(tmp_dir, dvc):


### PR DESCRIPTION
---

Fixes #11004

`dvc repro --force` rewrites a frozen stage's dependency hashes in `dvc.lock`, while plain `dvc repro` leaves them alone. Using the reproducer from the issue:

```
baseline         second_stage foo.py md5 = 7423db4d3117e33e9762e1496023ac70
after repro      second_stage foo.py md5 = 7423db4d3117e33e9762e1496023ac70
after repro -f   second_stage foo.py md5 = 1a6c3a03dc0c3289cd3c825982243c37
```

The stage is still `frozen: true` throughout, and its command is never re-run — only the recorded dependency hashes move. That leaves the lock no longer describing what the stage was actually built against, which is the thing freezing is for. The [`dvc freeze` docs](https://dvc.org/doc/command-reference/freeze) say a frozen stage is considered unchanged, so `--force` reproducing it reads as a bug rather than intended behaviour.

### Cause

`Stage.reproduce()` short-circuits every skip check when `force` is set:

```python
force = kwargs.get("force", False)
...
if force:
    pass
elif not self.changed(allow_missing, upstream):
    ...
    return None
```

Without `--force` a frozen stage exits through that `elif` — `changed_deps()` returns `False` for a frozen stage — so `_reproduce_stage` never calls `stage.dump()` and the lock is untouched. With `--force` it falls through to `self.run(...)`. `run()` still refuses to execute the command (`elif not self.frozen and self.cmd`), but the stage is re-saved afterwards and the lock is rewritten.

### Change

`force` is neutralised for frozen non-import stages, so they go through the same checks as an unforced run.

It deliberately does not `return None` outright. `changed()` is `changed_stage() or changed_deps() or changed_outs()`, and only the middle one is short-circuited by `frozen` — so a frozen stage whose **outputs** are missing still reaches `run()` and restores/verifies them, exactly as it does today without `--force`. Import stages are excluded, matching the existing `stage.frozen and not stage.is_import` condition in `_reproduce_stage` and the import handling in `run()`.

### Tests

`test_repro_frozen_force` freezes a stage, changes an upstream dependency, runs `reproduce(force=True)`, and asserts both that nothing is reproduced and that the stage's `dvc.lock` entry is byte-identical. It fails on `main` and passes with this change.

`tests/func/repro/` and `tests/unit/stage/` pass: **164 passed**. Two failures in `tests/unit/stage/` — `test_fill_from_lock_use_appropriate_checksum` and `test_dump_nondefault_hash` — fail identically on `main` without this change, so they are pre-existing and unrelated. `ruff check` and `ruff format --check` are clean on the changed files (the one remaining `too-many-positional-arguments` in `dvc/stage/__init__.py` is pre-existing and untouched).
