### PR TITLE
fix: match boolean environment values exactly

### DIFF
--- a/dvc/utils/__init__.py
+++ b/dvc/utils/__init__.py
@@ -244,7 +244,7 @@ def env2bool(var, undefined=False):
     var = os.getenv(var, None)
     if var is None:
         return undefined
-    return bool(re.search("1|y|yes|true", var, flags=re.IGNORECASE))
+    return var.strip().lower() in {"1", "y", "yes", "true"}
 
 
 def resolve_output(inp: str, out: Optional[str], force=False) -> str:

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -3,7 +3,14 @@ import re
 
 import pytest
 
-from dvc.utils import dict_sha256, fix_env, parse_target, relpath, resolve_output
+from dvc.utils import (
+    dict_sha256,
+    env2bool,
+    fix_env,
+    parse_target,
+    relpath,
+    resolve_output,
+)
 
 
 @pytest.mark.skipif(os.name == "nt", reason="pyenv-win is not supported")
@@ -123,6 +130,26 @@ def test_hint_on_lockfile():
     ) as e:
         assert parse_target("dvc.lock:name")
     assert "dvc.yaml:name" in str(e.value)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("1", True),
+        ("Y", True),
+        (" yes ", True),
+        ("TRUE", True),
+        ("0", False),
+        ("no", False),
+        ("false", False),
+        ("my_branch", False),
+        ("v1.0", False),
+    ],
+)
+def test_env2bool_matches_the_entire_value(value, expected, monkeypatch):
+    monkeypatch.setenv("DVC_TEST_ENV2BOOL", value)
+
+    assert env2bool("DVC_TEST_ENV2BOOL") is expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

`env2bool` uses an unanchored regex search, so unrelated values containing `y` or `1`, such as `my_branch` and `v1.0`, enable DVC environment flags. Only complete recognized affirmative tokens should evaluate to true.

Fixes #11080.

## Fix

Normalize surrounding whitespace and case, then compare against the existing affirmative vocabulary: `1`, `y`, `yes`, and `true`. Unset-variable behavior and recognized values are unchanged.

## Tests

- `uv run pytest tests/unit/utils/test_utils.py::test_env2bool_matches_the_entire_value -q` — 9 passed
- `uv run pytest tests/unit/utils/test_utils.py -q` — 43 passed, 1 skipped (Windows-specific)
- `uvx ruff check dvc/utils/__init__.py tests/unit/utils/test_utils.py` — passed
- `uvx ruff format --check dvc/utils/__init__.py tests/unit/utils/test_utils.py` — passed
- `git diff --check` — passed

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [x] 📖 This focused behavior fix does not require a documentation update.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
