### PR TITLE
repro: preserve successful stage gitignore entries

### DIFF
--- a/dvc/repo/reproduce.py
+++ b/dvc/repo/reproduce.py
@@ -199,6 +199,9 @@ def _reproduce(
 
         if ret:
             result.append(ret)
+            # Keep ignore entries from successful stages when a later stage
+            # fails and the surrounding reproduction context is unwound.
+            stage.repo.scm_context.commit_ignored_paths()
 
     if on_error != "ignore" and failed:
         _raise_error(None, *failed)

--- a/dvc/repo/scm_context.py
+++ b/dvc/repo/scm_context.py
@@ -95,6 +95,10 @@ class SCMContext:
             return self.track_file(relpath(gitignore_file))
         return None
 
+    def commit_ignored_paths(self) -> None:
+        """Keep ignore entries created by a completed operation."""
+        self.ignored_paths.clear()
+
     @contextmanager
     def __call__(
         self, autostage: Optional[bool] = None, quiet: Optional[bool] = None

--- a/tests/func/repro/test_repro.py
+++ b/tests/func/repro/test_repro.py
@@ -43,6 +43,29 @@ def test_repro_fail(tmp_dir, dvc, copy_script):
     assert main(["repro", stage.addressing]) != 0
 
 
+def test_repro_failure_keeps_successful_stage_gitignore(tmp_dir, dvc, scm):
+    (tmp_dir / PROJECT_FILE).dump(
+        {
+            "stages": {
+                "stage1": {
+                    "cmd": "mkdir -p output && echo ok > output/out1",
+                    "outs": ["output/out1"],
+                },
+                "stage2": {
+                    "cmd": "cp output/out1 output/out2 && exit 1",
+                    "deps": ["output/out1"],
+                    "outs": ["output/out2"],
+                },
+            }
+        }
+    )
+
+    with pytest.raises(ReproductionError):
+        dvc.reproduce()
+
+    assert (tmp_dir / "output" / ".gitignore").read_text().splitlines() == ["/out1"]
+
+
 def test_repro_frozen(tmp_dir, dvc, run_copy):
     (data_stage,) = tmp_dir.dvc_gen("data", "foo")
     stage0 = run_copy("data", "stage0", name="copy-data-stage0")


### PR DESCRIPTION
Fixes #11091

When a pipeline stage completes, keep its generated .gitignore entries committed to the reproduction result. If a later stage fails, only ignore entries created by the failing operation should be rolled back.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.
* [ ] 📖 This PR does not require documentation updates.

Validation:
- PATH="$PWD/.venv/bin:$PATH" .venv/bin/pytest -q tests/func/repro/test_repro.py
- PATH="$PWD/.venv/bin:$PATH" .venv/bin/pytest -q tests/unit/repo/test_reproduce.py tests/unit/repo/test_scm_context.py
- .venv/bin/mypy dvc/repo/reproduce.py dvc/repo/scm_context.py
- ruff check and ruff format --check on changed files.