### PR TITLE
ignore: preserve negations below descendant-only patterns

### DIFF
--- a/dvc/ignore.py
+++ b/dvc/ignore.py
@@ -194,15 +194,19 @@ class DvcIgnorePatterns(DvcIgnore):
     def _find_matching_pattern(
         self, path: str, is_dir: bool
     ) -> tuple[bool, list[PatternInfo]]:
-        paths = [path]
-        if is_dir and not path.endswith("/"):
-            paths.append(f"{path}/")
+        if is_dir:
+            path = path.rstrip("/")
 
         for pattern, ignore, dir_only_pattern, pattern_map in reversed(
             self.ignore_spec
         ):
             if dir_only_pattern and not is_dir:
                 continue
+            paths = [path]
+            if dir_only_pattern:
+                # `X/**` applies to X's contents, while a directory-only
+                # `X/` needs the trailing slash to match X itself.
+                paths.append(f"{path}/")
             for p in paths:
                 match = pattern.match(p)
                 if not match:

--- a/tests/unit/test_ignore.py
+++ b/tests/unit/test_ignore.py
@@ -185,6 +185,54 @@ def test_match_ignore_from_file(
     )
 
 
+@pytest.mark.parametrize(
+    "parent_pattern, expected",
+    [
+        ("volumes/functions/**", False),
+        ("volumes/functions/", True),
+    ],
+)
+def test_reinclude_below_parent_pattern(parent_pattern, expected):
+    ignore = DvcIgnorePatterns(
+        [parent_pattern, "!volumes/functions/deno.json"], os.sep, os.sep
+    )
+
+    def match(path, is_dir=False):
+        result, patterns = ignore.matches(os.sep, path, is_dir, details=True)
+        return result, [pattern.patterns for pattern in patterns]
+
+    expected_file_pattern = (
+        parent_pattern if expected else "!volumes/functions/deno.json"
+    )
+    assert match(join("volumes", "functions", "deno.json")) == (
+        expected,
+        [expected_file_pattern],
+    )
+    assert match(join("volumes", "functions", "other.py")) == (
+        True,
+        [parent_pattern],
+    )
+
+    expected_parent = (expected, [parent_pattern] if expected else [])
+    assert match(join("volumes", "functions"), is_dir=True) == expected_parent
+    assert match(join("volumes", "functions", ""), is_dir=True) == expected_parent
+
+
+@pytest.mark.parametrize(
+    "pattern, directory",
+    [
+        ("foo", "foo"),
+        ("foo*", "foobar"),
+        ("data/*", join("data", "subdir")),
+    ],
+)
+def test_file_pattern_matches_directory(pattern, directory):
+    ignore = DvcIgnorePatterns([pattern], os.sep, os.sep)
+
+    assert ignore.matches(os.sep, directory, True)
+    assert ignore.matches(os.sep, join(directory, ""), True)
+
+
 @pytest.mark.parametrize("sub_dir", ["", "dir"])
 @pytest.mark.parametrize("omit_dir", [".git", ".hg", ".dvc"])
 def test_should_ignore_dir(omit_dir, sub_dir):


### PR DESCRIPTION
Fixes #11095.

Directory matching previously tried a synthetic trailing slash for every pattern. This made `X/**` match `X` itself, stopping ancestor traversal before a later file negation could take effect.

This change normalizes directory paths and restricts the synthetic slash probe to explicit directory-only patterns. It allows `!volumes/functions/deno.json` beneath `volumes/functions/**`, while preserving `X/` exclusions and ordinary directory patterns such as `foo`, `foo*`, and `data/*`.

Tests cover the negated file, ignored sibling, parent with and without a trailing separator, and matching-pattern attribution.

### Validation

Tested commit: `98e5d51dedb4d69dffadb1ba80822b35eb9d8bcb`.

- Before the fix, the focused regression exited 1 with 1 failed and 1 passed; `X/**` incorrectly returned ignored while the `X/` control passed.
- Expanding the regression exposed the trailing-slash variant: 1 failed and 1 passed, returning `(True, ['volumes/functions/**'])` instead of `(False, [])`.
- The final unit ignore suite passed 62 tests with each of pathspec 0.10.3 and 1.1.1.
- The combined unit/functional ignore suites passed 110 tests.
- The full unit suite passed 1,370 tests with 4 platform-specific skips.
- Ruff, mypy, scoped pre-commit hooks, and `git diff --check` passed.
- A Git/DVC CLI comparison agreed: under `X/**`, the negated file is included and its sibling remains ignored; under `X/`, the negated file remains ignored.

Independent review reran both 62-test compatibility checks, 21 functional check-ignore tests, Ruff checks, and diff validation. Broader results above are from the implementation run.

AI assistance was used for implementation and independent review. Native Windows execution and the full functional suite were not run.

* [x] ❗ I have followed the [Contributing to DVC](https://dvc.org/doc/user-guide/contributing/core) checklist.

* [ ] 📖 If this PR requires [documentation](https://dvc.org/doc) updates, I have created a separate PR (or issue, at least) in [dvc.org](https://github.com/treeverse/dvc.org) and linked it here.

Documentation: no update is proposed because this restores existing ignore semantics without changing the public interface.

Thank you for the contribution - we'll try to review it as soon as possible. 🙏
