### PR TITLE
lockfile: key params by def_path to match how they are loaded

### DIFF
--- a/dvc/stage/serialize.py
+++ b/dvc/stage/serialize.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
     from dvc.stage import PipelineStage, Stage
 
 PARAM_PARAMS = ParamsDependency.PARAM_PARAMS
-PARAM_PATH = ParamsDependency.PARAM_PATH
 
 PARAM_DEPS = StageParams.PARAM_DEPS
 PARAM_OUTS = StageParams.PARAM_OUTS
@@ -101,8 +100,7 @@ def _serialize_params_values(params: list[ParamsDependency]):
     """
     key_vals = OrderedDict()
     for param_dep in sorted(params, key=attrgetter("def_path")):
-        dump = param_dep.dumpd()
-        path, params = dump[PARAM_PATH], dump[PARAM_PARAMS]
+        path, params = param_dep.def_path, param_dep.dumpd()[PARAM_PARAMS]
         if isinstance(params, dict):
             kv = [(key, params[key]) for key in sorted(params.keys())]
             key_vals[path] = OrderedDict(kv)

--- a/tests/func/test_status.py
+++ b/tests/func/test_status.py
@@ -138,6 +138,18 @@ def test_status_outputs(tmp_dir, dvc):
     }
 
 
+def test_params_file_with_dot_slash_path(tmp_dir, dvc):
+    tmp_dir.gen("my_params.yaml", "foo: 1")
+    dvc.stage.add(
+        name="test", cmd="echo my_params.yaml", params=[{"./my_params.yaml": None}]
+    )
+    dvc.reproduce()
+    assert (tmp_dir / "dvc.lock").parse()["stages"]["test"]["params"] == {
+        "./my_params.yaml": {"foo": 1}
+    }
+    assert dvc.status() == {}
+
+
 def test_params_without_targets(tmp_dir, dvc):
     dvc.stage.add(name="test", cmd="echo params.yaml", params=[{"params.yaml": None}])
     assert dvc.status() == {"test": [{"changed deps": {"params.yaml": "deleted"}}]}

--- a/tests/unit/stage/test_loader_pipeline_file.py
+++ b/tests/unit/stage/test_loader_pipeline_file.py
@@ -214,6 +214,22 @@ def test_load_stage_with_params(dvc, stage_data, lock_data):
     assert stage.outs[0].hash_info == HashInfo("md5", "bar_checksum")
 
 
+def test_load_stage_with_params_def_path_roundtrip(dvc, stage_data):
+    from dvc.stage.serialize import to_single_stage_lockfile
+
+    stage_data["params"] = [{"./my_params.yaml": None}]
+    dvcfile = load_file(dvc, PROJECT_FILE)
+    stage = StageLoader.load_stage(dvcfile, "stage-1", stage_data)
+    params, _ = split_params_deps(stage)
+    params[0].fill_values({"foo": 1})
+    lock_data = to_single_stage_lockfile(stage)
+
+    stage = StageLoader.load_stage(dvcfile, "stage-1", stage_data, lock_data)
+    params, _ = split_params_deps(stage)
+    assert params[0].def_path == "./my_params.yaml"
+    assert params[0].hash_info == HashInfo("params", {"foo": 1})
+
+
 @pytest.mark.parametrize("typ", ["metrics", "plots"])
 def test_load_stage_with_metrics_and_plots(dvc, stage_data, lock_data, typ):
     stage_data[typ] = stage_data.pop("outs")

--- a/tests/unit/stage/test_serialize_pipeline_lock.py
+++ b/tests/unit/stage/test_serialize_pipeline_lock.py
@@ -134,6 +134,17 @@ def test_lock_params_without_targets(dvc, info, expected):
     }
 
 
+def test_lock_params_keeps_def_path(dvc):
+    stage = create_stage(
+        PipelineStage, dvc, params=[{"./my_params.yaml": None}], **kwargs
+    )
+    stage.deps[0].fill_values({"foo": "foo"})
+    assert to_single_stage_lockfile(stage) == {
+        "cmd": "command",
+        "params": {"./my_params.yaml": OrderedDict({"foo": "foo"})},
+    }
+
+
 @pytest.mark.parametrize("typ", ["plots", "metrics", "outs"])
 def test_lock_outs(dvc, typ):
     stage = create_stage(PipelineStage, dvc, **{typ: ["input"]}, **kwargs)


### PR DESCRIPTION
## Problem

When a params file is written in `dvc.yaml` with a `./` prefix (e.g. `params: [./my_params.yaml]`), `dvc status` reports the whole file as `new` forever, and `dvc repro` re-runs the stage on every invocation, even though nothing changed:

```
$ dvc status
test:
	changed deps:
		new:                my_params.yaml
```

Reproduced on current `main` (3.67.2.dev) with the script from the issue.

## Root cause

`dvc.lock` entries for `deps` and `outs` are keyed verbatim by `def_path` (`dvc/stage/serialize.py:159`, `_dumpd`), but the `params` section is keyed through `Output.dumpd()` (`dvc/stage/serialize.py:104-105`, `_serialize_params_values`), which rewrites in-repo paths as `relpath(fs_path, stage.wdir)` (`dvc/output.py:843-846`). The lock therefore ends up with `params: {my_params.yaml: ...}` while the `ParamsDependency` keeps `def_path == "./my_params.yaml"`.

On load, `StageLoader.fill_from_lock` looks every item up by `def_path` (`dvc/stage/loader.py:63-65`): `get_in(lock_data, ["params", "./my_params.yaml"])` returns `None`, `fill_values` is a no-op, `hash_info.value` stays `None`, and `workspace_status` reports the whole file as `new`.

## Fix

Key the lockfile `params` section by `param_dep.def_path`, the same way `deps`/`outs` are already keyed in the same lockfile, so the serializer and the loader agree. One line in `_serialize_params_values`; the now-unused module constant `PARAM_PATH` is removed.

Lock files previously written with the normalized key are rewritten on the next `dvc repro`/`dvc commit` (which affected repos already trigger on every run today); after that the stage is reported clean.

## How tested

Added three tests that fail on `main` and pass with the fix:

- `tests/unit/stage/test_serialize_pipeline_lock.py::test_lock_params_keeps_def_path`
- `tests/unit/stage/test_loader_pipeline_file.py::test_load_stage_with_params_def_path_roundtrip` (serialize to lock, load back, values filled)
- `tests/func/test_status.py::test_params_file_with_dot_slash_path` (`stage add` + `reproduce`, then `status == {}`)

Before:

```
FAILED tests/unit/stage/test_serialize_pipeline_lock.py::test_lock_params_keeps_def_path
E     {'params': OrderedDict({'my_params.yaml': OrderedDict({'foo': 'foo'})})} != {'params': {'./my_params.yaml': OrderedDict({'foo': 'foo'})}}
FAILED tests/unit/stage/test_loader_pipeline_file.py::test_load_stage_with_params_def_path_roundtrip
E       name: None != 'params'
E       value: None != {'foo': 1}
FAILED tests/func/test_status.py::test_params_file_with_dot_slash_path
E   AssertionError: assert {'my_params.yaml': {'foo': 1}} == {'./my_params...': {'foo': 1}}
3 failed
```

After:

```
3 passed in 0.36s
```

`pytest tests/unit/stage tests/unit/dependency tests/func/test_status.py tests/func/params tests/func/test_lockfile.py tests/func/test_stage_load.py tests/func/test_run.py tests/func/test_stage.py` passes. `ruff check`, `ruff format --check` and `mypy` are clean on the changed files.

End-to-end with the script from the issue: `dvc.lock` now contains `params: {./my_params.yaml: {foo: 1}}`, `dvc status` prints "Data and pipelines are up to date.", a second `dvc repro` skips the stage, and editing `foo` is still reported as `modified`.

## Links

- Closes https://github.com/iterative/dvc/issues/9518

---

* [x] I have followed the Contributing to DVC checklist.

* [x] Documentation: no changes to the docs are needed for this fix.

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.
